### PR TITLE
feat: Use 'notes' bucket for Supabase storage

### DIFF
--- a/src/components/UploadNoteForm.tsx
+++ b/src/components/UploadNoteForm.tsx
@@ -53,14 +53,14 @@ export const UploadNoteForm: React.FC<UploadNoteFormProps> = ({ onUploadSuccess,
       // 1. Upload file to Supabase Storage
       const filePath = `${user.id}/${Date.now()}-${file.name}`;
       const { error: uploadError } = await supabase.storage
-        .from('notes-files')
+        .from('notes')
         .upload(filePath, file);
 
       if (uploadError) throw uploadError;
 
       // 2. Get public URL of the uploaded file
       const { data: { publicUrl } } = supabase.storage
-        .from('notes-files')
+        .from('notes')
         .getPublicUrl(filePath);
 
       if (!publicUrl) throw new Error('Could not get public URL for the file.');

--- a/supabase/migrations/20250726120000_create_storage_bucket.sql
+++ b/supabase/migrations/20250726120000_create_storage_bucket.sql
@@ -1,11 +1,11 @@
 /*
 # [Feature] Create Storage Bucket for Notes
-Creates the 'notes-files' storage bucket and sets up security policies for file uploads and downloads.
+Creates the 'notes' storage bucket and sets up security policies for file uploads and downloads.
 
 ## Query Description:
-This script initializes the file storage system for the application. It creates a new public bucket named 'notes-files' where all uploaded academic notes will be stored. It also configures the necessary security rules (Row Level Security) to control who can upload, download, update, and delete files.
+This script initializes the file storage system for the application. It creates a new public bucket named 'notes' where all uploaded academic notes will be stored. It also configures the necessary security rules (Row Level Security) to control who can upload, download, update, and delete files.
 
-- **Bucket Creation**: A new bucket `notes-files` is created.
+- **Bucket Creation**: A new bucket `notes` is created.
 - **Security Policies**:
   - **Faculty Uploads**: Only users with the 'faculty' role can upload new files.
   - **Authenticated Downloads**: Any logged-in user (student or faculty) can download files.
@@ -20,7 +20,7 @@ This operation is safe and does not affect existing data.
 - Reversible: true (Policies and bucket can be dropped)
 
 ## Structure Details:
-- Creates bucket: `storage.buckets('notes-files')`
+- Creates bucket: `storage.buckets('notes')`
 - Adds RLS policies to: `storage.objects`
 
 ## Security Implications:
@@ -36,38 +36,38 @@ This operation is safe and does not affect existing data.
 
 -- 1. Create the storage bucket for notes if it doesn't exist
 INSERT INTO storage.buckets (id, name, public)
-VALUES ('notes-files', 'notes-files', true)
+VALUES ('notes', 'notes', true)
 ON CONFLICT (id) DO NOTHING;
 
--- 2. Drop existing policies for 'notes-files' bucket to ensure a clean state
+-- 2. Drop existing policies for 'notes' bucket to ensure a clean state
 DROP POLICY IF EXISTS "Allow authenticated read access" ON storage.objects;
 DROP POLICY IF EXISTS "Allow faculty to upload notes" ON storage.objects;
 DROP POLICY IF EXISTS "Allow faculty to update their own notes" ON storage.objects;
 DROP POLICY IF EXISTS "Allow faculty to delete their own notes" ON storage.objects;
 
--- 3. Create RLS policies for the 'notes-files' bucket
+-- 3. Create RLS policies for the 'notes' bucket
 
 -- Allow authenticated users to view/download files
 CREATE POLICY "Allow authenticated read access"
 ON storage.objects FOR SELECT
 TO authenticated
-USING (bucket_id = 'notes-files');
+USING (bucket_id = 'notes');
 
 -- Allow faculty members to upload new files
 CREATE POLICY "Allow faculty to upload notes"
 ON storage.objects FOR INSERT
 TO authenticated
-WITH CHECK (bucket_id = 'notes-files' AND get_my_role() = 'faculty');
+WITH CHECK (bucket_id = 'notes' AND get_my_role() = 'faculty');
 
 -- Allow faculty members to update their own files
 CREATE POLICY "Allow faculty to update their own notes"
 ON storage.objects FOR UPDATE
 TO authenticated
-USING (auth.uid() = owner AND bucket_id = 'notes-files')
-WITH CHECK (auth.uid() = owner AND bucket_id = 'notes-files');
+USING (auth.uid() = owner AND bucket_id = 'notes')
+WITH CHECK (auth.uid() = owner AND bucket_id = 'notes');
 
 -- Allow faculty members to delete their own files
 CREATE POLICY "Allow faculty to delete their own notes"
 ON storage.objects FOR DELETE
 TO authenticated
-USING (auth.uid() = owner AND bucket_id = 'notes-files');
+USING (auth.uid() = owner AND bucket_id = 'notes');


### PR DESCRIPTION
Updates the application to use the 'notes' storage bucket instead of 'notes-files'.

This change modifies:
- The frontend component `UploadNoteForm.tsx` to reference the 'notes' bucket when uploading and retrieving file URLs.
- The database migration script `20250726120000_create_storage_bucket.sql` to create and configure the 'notes' bucket with the appropriate RLS policies.